### PR TITLE
Data API bug fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,10 +89,12 @@ function generateSignature(
     var signatureArray = [
         securityPacket.consumer_key,
         securityPacket.domain,
-        securityPacket.timestamp,
-        securityPacket.user_id,
-        secret
+        securityPacket.timestamp
     ];
+    if(securityPacket.user_id) {
+        signatureArray.push(securityPacket.user_id);
+    }
+    signatureArray.push(secret);
 
     // Add the requestPacket if necessary
     var signRequestData = !(service === 'assess' || service === 'questions');
@@ -173,7 +175,13 @@ LearnositySDK.init = function (
     );
 
     var output;
-    if (service === 'questions') {
+    if(service === 'data') {
+         output = {
+            'security': JSON.stringify(securityPacket),
+            'request': JSON.stringify(requestPacket),
+            'action': action
+        };
+    } else if (service === 'questions') {
         output = _.extend(securityPacket, requestPacket);
     } else {
         output = {


### PR DESCRIPTION
When used with the data API, the SDK does not return signed requests in an valid format resulting in authentication errors. Three causes were identified and fixed:

1. When the request does not have a user id, the signature array stores an empty element which results in an invalid signature.
2. The data API expects the signature and request JSON elements to be "stringified." The SDK does not return the request object in an immediately usable format.
3. The "action" verb is not appended to the request object even though it is used to generate the signature.

This pull request resolves all issues above, allowing the data API to be used as documented.