### PR TITLE
[DOC] Add DataAPI Examples to REFERENCE.md

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -14,6 +14,8 @@ The init function takes up to 5 arguments:
  * [request] request details *(optional)*
  * [string]  action *(optional)*
 
+ ## Items API Example
+
 ```
 Structure of Node.js project (based on Express.js and EJS template):
 - node_modules
@@ -129,6 +131,213 @@ package.json:
 ```
 run node.js application: node app.js
 check browser: http://localhost:3000/
+```
+
+ ## Data API - Example 1:
+
+ ``` javascript
+// vanilla node.js example with no dependencies required
+
+const Learnosity = require('learnosity-sdk-nodejs');
+
+/**
+ * 
+ * NOTE: 
+ * Native node Fetch API (still experimental) need to be enabled, and then the following global functions and classes are made available: fetch(), Request, Response, Headers, FormData
+ * To enable you should have node v18 or greater
+ * and then run 'node <FILENAME.js> --experimental-fetch' in the terminal to enable
+ */
+
+// instantiate the SDK
+const learnositySdk = new Learnosity();
+// Generate a Learnosity API initialization packet to the DataAPI
+const dataAPIRequest = learnositySdk.init(
+    // service type
+    'data',
+
+    // security details - dataAPIRequest.security 
+    {
+        consumer_key: 'yis0TYCu7U9V4o7M', // your actual consumer key here 
+        domain:       'localhost', // your actual domain here
+        user_id:      '23452345' // your user id
+    },
+    // secret 
+    '74c5fd430cf1242a527f6223aebd42d30464be22', // your actual consumer secret here
+    // request details - build your request object for the Data API here - dataAPIRequest.request
+    // this example fetches activities from our demos item bank w/ the following references
+    {
+        references : ["19935",
+        "00082a84-0a72-45bf-b465-e9e54b6094bc",
+        "7656ffc0-2cad-4cf0-884f-946cbb9a4bad"]
+    },
+     // action type - dataAPIRequest.action
+     'get'
+);
+
+const form = new FormData();
+/* Note: the same can be accomplished with using  URLSearchParams  (https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) *
+// const form = newURLSearchParams()
+*/
+form.append("security", dataAPIRequest.security);
+form.append("request", dataAPIRequest.request);
+form.append("action", dataAPIRequest.action);
+
+/* define an async/await data api call function that takes in:
+*
+* @param endpoint : string
+* @param requestParams : object
+*
+*/
+const makeDataAPICall = async (endpoint, requestParams) => {
+    // use 'await' save the successful response to a variable called dataAPIResponse
+    const dataAPIResponse = await fetch(endpoint, {
+      method: 'POST', // *GET, POST, PUT, DELETE, etc.
+      body: requestParams 
+    });
+    // return the response json
+    return dataAPIResponse.json(); 
+}
+
+// now call the fuction, passing in the desired endpoint (itembank/activities in this case)
+// and pass in the fromData object (saved to the variable called 'form' here), which contains the requestParams
+
+ makeDataAPICall('https://data.learnosity.com/v2022.1.LTS/itembank/activities', form)
+   .then(response => {
+    console.log("response from the data API", JSON.stringify(response, null, '\t'))
+   })
+   .catch(error => console.log('there was an error', error))
+```
+```
+run node.js application: node app.js
+check the terminal for the DataAPI response.
+```
+
+## Data API - Example 2, integration with Express.js
+
+```
+Structure of Node.js project (based on Express.js, Axios, and FormData):
+- node_modules
+----- express
+----- axios
+----- from-data
+----- learnosity-sdk-nodejs
+----- (all standard modules)
+- views
+----- index.ejs
+- package.json
+- package-lock.json
+- app.js
+```
+
+ ``` javascript
+// require learnosity sdk
+const Learnosity = require('learnosity-sdk-nodejs');
+// 3 other required dependencies for this example: (express, form-data, axios)
+const express = require('express');
+const FormData = require('form-data')
+const axios = require('axios');
+
+const app = express();
+
+
+// setting up a DATA API route using axios and express
+
+// initialize a get express route (to reflect that the action is 'get')
+// you can call this route anything you want - called learnosity-activities here to reflect that you want to get
+// your activities form Learnosity
+// use async await to await the response from the request to leanrosity 
+app.get('/learnosity-activities', async (req, res) => {
+    // instantiate the SDK
+    const learnositySdk = new Learnosity();
+    // Generate a Learnosity API initialization packet to the DataAPI
+    const dataAPIRequest = learnositySdk.init(
+        // service type
+        'data',
+
+        // security details - dataAPIRequest.security 
+        {
+            'consumer_key': 'yis0TYCu7U9V4o7M', // your actual consumer key here 
+            'domain':       'localhost', // your actual domain here
+            'user_id':      '1234567' // your user id
+        },
+        // secret 
+        '74c5fd430cf1242a527f6223aebd42d30464be22', // your actual consumer secret here
+        // request details - build your request object for the Data API here - dataAPIRequest.request
+        // this example fetches activities from our demos item bank w/ the following references
+        {
+            references : ["19935",
+            "00082a84-0a72-45bf-b465-e9e54b6094bc",
+            "7656ffc0-2cad-4cf0-884f-946cbb9a4bad"]
+        },
+         // action type - dataAPIRequest.action
+         'get'
+    );
+    
+    // use the form data npm package to append the initilization packet to the from object to be used in the axios request below
+    const form = new FormData();
+    /* Note: the same can be accomplished with using  URLSearchParams  (https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) *
+    // const form = newURLSearchParams()
+    */
+    form.append("security", dataAPIRequest.security);
+    form.append("request", dataAPIRequest.request);
+    form.append("action", dataAPIRequest.action);
+
+
+    // now make a POST request to the desired endpoint of Data API using axios, including the form data in the post request  
+    // using 'await' save the successful response to a variable called dataAPIResponse
+    const dataAPIResponse = await axios.post('https://data.learnosity.com/v2022.1.LTS/itembank/activities', form, {
+    headers: form.getHeaders()
+  })
+  .then(res => {
+    console.log(`statusCode: ${res.status}`);
+    return res.data;
+  })
+  .catch(error => {
+    console.log(error);
+  })
+
+  // log the pretified response to the console using JSON.stringify
+  console.log("response from the data API", JSON.stringify(dataAPIResponse, null, '\t'))
+  // send the response on using the express res.send() method. 
+  res.send(dataAPIResponse)
+});
+
+// generic message
+app.get('/', (req,res) => {
+  res.send("welcome to the NodeSDK + Express + DataAPI example. Go to /learnosity-activities to fetch the data")
+})
+
+app.listen(3000, function () {
+    console.log('Example app listening on port 3000!');
+});
+```
+``` json
+package.json:
+
+{
+  "name": "nodesdk",
+  "version": "1.0.0",
+  "description": "Test Node JS SDK",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node app.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "axios": "^0.27.2",
+    "express": "^4.18.1",
+    "form-data": "^4.0.0",
+    "learnosity-sdk-nodejs": "github:Learnosity/learnosity-sdk-nodejs"
+  }
+}
+```
+
+```
+run node.js application: node app.js
+check browser or postman: http://localhost:3000/learnosity-activities to see DataAPI response.
 ```
 
 #### Init() Arguments

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -222,8 +222,6 @@ Structure of Node.js project (based on Express.js, Axios, and FormData):
 ----- from-data
 ----- learnosity-sdk-nodejs
 ----- (all standard modules)
-- views
------ index.ejs
 - package.json
 - package-lock.json
 - app.js

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -14,7 +14,7 @@ The init function takes up to 5 arguments:
  * [request] request details *(optional)*
  * [string]  action *(optional)*
 
- ## Items API Example
+## Items API Example
 
 ```
 Structure of Node.js project (based on Express.js and EJS template):
@@ -133,76 +133,75 @@ run node.js application: node app.js
 check browser: http://localhost:3000/
 ```
 
- ## Data API - Example 1:
+## Data API - Example 1
 
  ``` javascript
  app.js:
 
-// vanilla node.js example with no dependencies required
+// Vanilla node.js example with no dependencies required.
 const Learnosity = require('learnosity-sdk-nodejs');
 
-/**
- * 
+/*
  * NOTE: 
  * For this example native node Fetch API (still experimental) needs to be enabled, 
  * and then the following global functions and classes are made available: fetch(), Request, Response, Headers, FormData.
  * To enable Fetch in node you should use v18 or greater.
- * run 'node --experimental-fetch' or 'node <FILENAME.js> --experimental-fetch' in the terminal to enable
+ * Run 'node --experimental-fetch' or 'node <FILENAME.js> --experimental-fetch' in the terminal to enable
  */
 
-// instantiate the SDK
+// Instantiate the SDK
 const learnositySdk = new Learnosity();
-// Generate a Learnosity API initialization packet to the DataAPI
+// Generate a Learnosity API initialization packet to the Data API
 const dataAPIRequest = learnositySdk.init(
-    // service type
+    // Set the service type
     'data',
 
-    // security details - dataAPIRequest.security 
+    // Security details - dataAPIRequest.security 
     {
-        consumer_key: 'yis0TYCu7U9V4o7M', // your actual consumer key here 
-        domain:       'localhost', // your actual domain here
-        user_id:      '23452345' // your user id
+        consumer_key: 'yis0TYCu7U9V4o7M', // Your actual consumer key goes here 
+        domain:       'localhost', // Your actual domain goes here
+        user_id:      '23452345' // Your user id goes here
     },
     // secret 
-    '74c5fd430cf1242a527f6223aebd42d30464be22', // your actual consumer secret here
-    // request details - build your request object for the Data API here - dataAPIRequest.request
-    // this example fetches activities from our demos item bank w/ the following references
+    '74c5fd430cf1242a527f6223aebd42d30464be22', // Your actual consumer secret here
+    /* Request details - build your request object for the Data API here - 
+    dataAPIRequest.request 
+    This example fetches activities from our demos Item bank w/ the following references: */
     {
         references : ["19935",
         "00082a84-0a72-45bf-b465-e9e54b6094bc",
         "7656ffc0-2cad-4cf0-884f-946cbb9a4bad"]
     },
-     // action type - dataAPIRequest.action
+     // Action type - dataAPIRequest.action
      'get'
 );
 
 const form = new FormData();
 /* Note: the same can be accomplished with using URLSearchParams 
-(https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) *
-// const form = new URLSearchParams()
+(https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
+ const form = new URLSearchParams()
 */
 form.append("security", dataAPIRequest.security);
 form.append("request", dataAPIRequest.request);
 form.append("action", dataAPIRequest.action);
 
-/* define an async/await data api call function that takes in:
+/* Define an async/await data api call function that takes in the following:
 *
 * @param endpoint : string
 * @param requestParams : object
 *
 */
 const makeDataAPICall = async (endpoint, requestParams) => {
-    // use 'await' save the successful response to a variable called dataAPIResponse
+    // Use 'await' save the successful response to a variable called dataAPIResponse
     const dataAPIResponse = await fetch(endpoint, {
       method: 'POST', // *GET, POST, PUT, DELETE, etc.
       body: requestParams 
     });
-    // return the response json
+    // Return the response JSON
     return dataAPIResponse.json(); 
 }
 
-// now call the fuction, passing in the desired endpoint (itembank/activities in this case)
-// and pass in the fromData object (saved to the variable called 'form' here), which contains the requestParams
+/* Now call the function, passing in the desired endpoint (itembank/activities in this case), and pass in the fromData object (saved to the variable called 'form' here), which contains the requestParams: */
 
  makeDataAPICall('https://data.learnosity.com/v2022.1.LTS/itembank/activities', form)
    .then(response => {
@@ -210,6 +209,7 @@ const makeDataAPICall = async (endpoint, requestParams) => {
    })
    .catch(error => console.log('there was an error', error))
 ```
+
 ```
 run node.js application: node app.js
 check the terminal for the DataAPI response.
@@ -233,60 +233,52 @@ Structure of Node.js project (based on Express.js, Axios, and FormData):
  ``` javascript
  app.js:
 
-// require learnosity sdk
+// Require Learnosity SDK:
 const Learnosity = require('learnosity-sdk-nodejs');
-// 3 other required dependencies for this example: (express, form-data, axios)
+// Three other required dependencies for this example: (express, form-data, axios):
 const express = require('express');
 const FormData = require('form-data')
 const axios = require('axios');
 
 const app = express();
 
-
-// setting up a DATA API route using axios and express
-
-// initialize a get express route (to reflect that the action is 'get')
-// you can call this route anything you want - called learnosity-activities here to reflect that you want to get
-// your activities form Learnosity
-// use async await to await the response from the request to leanrosity 
+/* Setting up a DATA API route using axios and express. Initialize a get express route (to reflect that the action is 'get'). You can call this route anything you want - called learnosity-activities here to reflect that you want to get your Activities from Learnosity.Use async await to await the response from the request to Learnosity. */
 app.get('/learnosity-activities', async (req, res) => {
-    // instantiate the SDK
+    // Instantiate the SDK
     const learnositySdk = new Learnosity();
     // Generate a Learnosity API initialization packet to the DataAPI
     const dataAPIRequest = learnositySdk.init(
-        // service type
+        // Set the service type
         'data',
 
-        // security details - dataAPIRequest.security 
+        // Security details - dataAPIRequest.security 
         {
-            'consumer_key': 'yis0TYCu7U9V4o7M', // your actual consumer key here 
-            'domain':       'localhost', // your actual domain here
-            'user_id':      '1234567' // your user id
+            'consumer_key': 'yis0TYCu7U9V4o7M', // Your actual consumer key 
+            'domain':       'localhost', // Your actual domain
+            'user_id':      '1234567' // User ID
         },
-        // secret 
-        '74c5fd430cf1242a527f6223aebd42d30464be22', // your actual consumer secret here
-        // request details - build your request object for the Data API here - dataAPIRequest.request
-        // this example fetches activities from our demos item bank w/ the following references
+        // Your actual consumer secret (note, this is the demo consumer)
+        '74c5fd430cf1242a527f6223aebd42d30464be22',
+        /* Request details - build your request object for the Data API here - dataAPIRequest.request. This example fetches Activities from our demos Item bank with the following references: */
         {
             references : ["19935",
             "00082a84-0a72-45bf-b465-e9e54b6094bc",
             "7656ffc0-2cad-4cf0-884f-946cbb9a4bad"]
         },
-         // action type - dataAPIRequest.action
+         // Action type - dataAPIRequest.action
          'get'
     );
     
-    /* use the form-data npm package to append the initilization packet 
-    to the from object to be used in the axios request below */
+    /* Use the form-data npm package to append the initilization packet 
+    to the from object to be used in the axios request below. */
     const form = new FormData();
     /* Note: the same can be accomplished with using  URLSearchParams  
-    (https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) *
-    // const form = newURLSearchParams()
+    (https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
+     const form = newURLSearchParams()
     */
     form.append("security", dataAPIRequest.security);
     form.append("request", dataAPIRequest.request);
     form.append("action", dataAPIRequest.action);
-
 
     /* Now make a POST request to the desired endpoint of Data API.
     This example uses axios, and we include the form data in the POST request. */
@@ -303,13 +295,13 @@ app.get('/learnosity-activities', async (req, res) => {
     console.log(error);
   })
 
-  // log the pretified response to the console using JSON.stringify
+  // Log the pretified response to the console using JSON.stringify
   console.log("response from the data API", JSON.stringify(dataAPIResponse, null, '\t'))
-  // send the response on using the express res.send() method. 
+  // Send the response on using the express res.send() method
   res.send(dataAPIResponse)
 });
 
-// generic message
+// Generic message
 app.get('/', (req,res) => {
   res.send("welcome to the NodeSDK + Express + DataAPI example. Go to /learnosity-activities to fetch the data")
 })
@@ -318,6 +310,7 @@ app.listen(3000, function () {
     console.log('Example app listening on port 3000!');
 });
 ```
+
 ``` json
 package.json:
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -136,16 +136,18 @@ check browser: http://localhost:3000/
  ## Data API - Example 1:
 
  ``` javascript
-// vanilla node.js example with no dependencies required
+ app.js:
 
+// vanilla node.js example with no dependencies required
 const Learnosity = require('learnosity-sdk-nodejs');
 
 /**
  * 
  * NOTE: 
- * Native node Fetch API (still experimental) need to be enabled, and then the following global functions and classes are made available: fetch(), Request, Response, Headers, FormData
- * To enable you should have node v18 or greater
- * and then run 'node <FILENAME.js> --experimental-fetch' in the terminal to enable
+ * For this example native node Fetch API (still experimental) needs to be enabled, 
+ * and then the following global functions and classes are made available: fetch(), Request, Response, Headers, FormData.
+ * To enable Fetch in node you should use v18 or greater.
+ * run 'node --experimental-fetch' or 'node <FILENAME.js> --experimental-fetch' in the terminal to enable
  */
 
 // instantiate the SDK
@@ -175,8 +177,9 @@ const dataAPIRequest = learnositySdk.init(
 );
 
 const form = new FormData();
-/* Note: the same can be accomplished with using  URLSearchParams  (https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) *
-// const form = newURLSearchParams()
+/* Note: the same can be accomplished with using URLSearchParams 
+(https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) *
+// const form = new URLSearchParams()
 */
 form.append("security", dataAPIRequest.security);
 form.append("request", dataAPIRequest.request);
@@ -212,7 +215,7 @@ run node.js application: node app.js
 check the terminal for the DataAPI response.
 ```
 
-## Data API - Example 2, integration with Express.js
+## Data API - Example 2, integration with Express.js:
 
 ```
 Structure of Node.js project (based on Express.js, Axios, and FormData):
@@ -228,6 +231,8 @@ Structure of Node.js project (based on Express.js, Axios, and FormData):
 ```
 
  ``` javascript
+ app.js:
+
 // require learnosity sdk
 const Learnosity = require('learnosity-sdk-nodejs');
 // 3 other required dependencies for this example: (express, form-data, axios)
@@ -271,9 +276,11 @@ app.get('/learnosity-activities', async (req, res) => {
          'get'
     );
     
-    // use the form data npm package to append the initilization packet to the from object to be used in the axios request below
+    /* use the form-data npm package to append the initilization packet 
+    to the from object to be used in the axios request below */
     const form = new FormData();
-    /* Note: the same can be accomplished with using  URLSearchParams  (https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) *
+    /* Note: the same can be accomplished with using  URLSearchParams  
+    (https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) *
     // const form = newURLSearchParams()
     */
     form.append("security", dataAPIRequest.security);
@@ -281,8 +288,10 @@ app.get('/learnosity-activities', async (req, res) => {
     form.append("action", dataAPIRequest.action);
 
 
-    // now make a POST request to the desired endpoint of Data API using axios, including the form data in the post request  
-    // using 'await' save the successful response to a variable called dataAPIResponse
+    /* Now make a POST request to the desired endpoint of Data API.
+    This example uses axios, and we include the form data in the POST request. */
+
+    // Using 'await' to save the successful response to a variable called dataAPIResponse 
     const dataAPIResponse = await axios.post('https://data.learnosity.com/v2022.1.LTS/itembank/activities', form, {
     headers: form.getHeaders()
   })

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -143,10 +143,12 @@ const Learnosity = require('learnosity-sdk-nodejs');
 
 /*
  * NOTE: 
- * For this example native node Fetch API (still experimental) needs to be enabled, 
- * and then the following global functions and classes are made available: fetch(), Request, Response, Headers, FormData.
+ * For this example native node Fetch API (still experimental) needs to be 
+ * enabled, and then the following global functions and classes are made 
+ * available: fetch(), Request, Response, Headers, FormData.
  * To enable Fetch in node you should use v18 or greater.
- * Run 'node --experimental-fetch' or 'node <FILENAME.js> --experimental-fetch' in the terminal to enable
+ * Run 'node --experimental-fetch' or 
+ * 'node <FILENAME.js> --experimental-fetch' in the terminal to enable
  */
 
 // Instantiate the SDK
@@ -215,7 +217,7 @@ run node.js application: node app.js
 check the terminal for the DataAPI response.
 ```
 
-## Data API - Example 2, integration with Express.js:
+## Data API - Example 2, integration with Express.js
 
 ```
 Structure of Node.js project (based on Express.js, Axios, and FormData):
@@ -337,7 +339,8 @@ package.json:
 
 ```
 run node.js application: node app.js
-check browser or postman: http://localhost:3000/learnosity-activities to see DataAPI response.
+Check your browser or postman: http://localhost:3000/learnosity-activities to
+see the Data API response.
 ```
 
 #### Init() Arguments


### PR DESCRIPTION
PR with 2 examples of DataAPI helper functions.

Example 1: Uses vanilla Node with Native Fetch library (still experimental currently)

Example 2: Uses Express, Axios, and form-data npm dependencies