### PR TITLE
Update JSDoc comments for improved type hints in tsserver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER := $(if $(LRN_SDK_NO_DOCKER),,$(shell which docker))
 NODE_VERSION = 16
 
-TARGETS = build test clean test-unit install-deps audit-deps lint lint-fix
+TARGETS = build test clean test-unit install-deps audit-deps lint lint-fix generate-types
 .PHONY: $(TARGETS)
 
 ifneq (,$(DOCKER))
@@ -43,4 +43,7 @@ lint:
 
 lint-fix:
 	npm run lint -- --fix
+
+generate-types:
+	npx tsc
 endif

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,58 @@
+export = LearnositySDK;
+/**
+ * @constructor
+ */
+declare function LearnositySDK(): void;
+declare class LearnositySDK {
+    /**
+     * @see https://github.com/Learnosity/learnosity-sdk-nodejs For more information
+     *
+     * @param {Service} service
+     * @param {SecurityPacket} securityPacket
+     * @param {string} secret
+     * @param {RequestPacket} requestPacket
+     * @param {Action} [action]
+     *
+     * @returns object The init options for a Learnosity API
+     */
+    init(service: Service, securityPacket: SecurityPacket, secret: string, requestPacket: RequestPacket, action?: Action): any;
+}
+declare namespace LearnositySDK {
+    export { enableTelemetry, disableTelemetry, SecurityPacket, SDKMeta, RequestMeta, RequestPacket, Service, Action };
+}
+/**
+ * Enables telemetry.
+ *
+ * Telemetry is enabled by default. We use it to enable better support and feature planning.
+ * It is however not advised to disable it, and it will not interfere with any usage.
+ */
+declare function enableTelemetry(): void;
+/**
+ * Disables telemetry.
+ *
+ * We use telemetry to enable better support and feature planning. It is therefore not advised to
+ * disable it, because it will not interfere with any usage.
+ */
+declare function disableTelemetry(): void;
+type SecurityPacket = {
+    consumer_key: string;
+    domain: string;
+    timestamp?: `${number}-${number}`;
+    user_id?: string;
+    expires?: string;
+};
+type SDKMeta = {
+    version: string;
+    lang: string;
+    lang_version: string;
+    platform: NodeJS.Platform;
+    platform_version: string;
+};
+type RequestMeta = {
+    meta?: {
+        sdk?: SDKMeta;
+    };
+};
+type RequestPacket = Record<string, any> & RequestMeta;
+type Service = 'assess' | 'author' | 'items' | 'reports' | 'questions' | 'data';
+type Action = 'get' | 'set' | 'update';

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ const moduleInfo = require('./package.json');
  *  Converts the request packet into an object if it is passed as a string
  *
  * @param {RequestPacket | string} requestPacket
- * @returns RequestPacket
+ * @returns {RequestPacket}
  */
 function convertRequestPacketToObject(requestPacket) {
     if (_.isString(requestPacket)) {

--- a/index.js
+++ b/index.js
@@ -17,10 +17,45 @@ const os = require('os');
 const moduleInfo = require('./package.json');
 
 /**
+ * @typedef {Object} SecurityPacket
+ * @property {string} consumer_key
+ * @property {string} domain
+ * @property {string} [timestamp]
+ * @property {string} [user_id]
+ * @property {string} [expires]
+ */
+
+/**
+ * @typedef {Object} SDKMeta
+ * @property {string} version
+ * @property {string} lang
+ * @property {string} lang_version
+ * @property {NodeJS.Platform} platform
+ * @property {string} platform_version
+ */
+
+/**
+ * @typedef {Object} RequestMeta
+ * @property {{sdk?: SDKMeta}} [meta]
+ */
+
+/**
+ * @typedef {Record<string, any> & RequestMeta} RequestPacket
+ */
+
+/**
+ * @typedef {'assess' | 'author' | 'items' | 'reports' | 'questions' | 'data'} Service
+ */
+
+/**
+ * @typedef {'get' | 'set' | 'update'} Action
+ */
+
+/**
  *  Converts the request packet into an object if it is passed as a string
  *
- * @param requestPacket
- * @returns object
+ * @param {RequestPacket | string} requestPacket
+ * @returns RequestPacket
  */
 function convertRequestPacketToObject(requestPacket) {
     if (_.isString(requestPacket)) {
@@ -30,6 +65,7 @@ function convertRequestPacketToObject(requestPacket) {
     }
 }
 
+/** @type {SDKMeta} */
 const sdkMeta = {
     version: 'v' + moduleInfo.version,
     lang: 'node.js',
@@ -54,9 +90,9 @@ function addTelemetryData(requestObject) {
 /**
  * Insert security information into assess request object
  *
- * @param requestPacket    requestPacket is mutated as a result.
- * @param securityPacket
- * @param secret
+ * @param {RequestPacket} requestPacket - requestPacket is mutated as a result.
+ * @param {SecurityPacket} securityPacket
+ * @param {string} secret
  */
 function insertSecurityInformationToAssessObject(requestPacket, securityPacket, secret) {
     if (requestPacket.questionsApiActivity) {
@@ -84,11 +120,11 @@ function insertSecurityInformationToAssessObject(requestPacket, securityPacket, 
 /**
  * Creates the signature hash.
  *
- * @param service        string
- * @param securityPacket object
- * @param secret         string
- * @param requestString  string
- * @param action         object
+ * @param {string} service
+ * @param {SecurityPacket} securityPacket
+ * @param {string} secret
+ * @param {string} requestString
+ * @param {Action} action
  */
 function generateSignature(
     service,
@@ -129,9 +165,9 @@ function generateSignature(
 /**
  * Joins an array (with '_') and hashes it.
  *
- * @param signatureArray array
- * @param secret
- * @returns string
+ * @param {string[]} signatureArray
+ * @param {string} secret
+ * @returns {string}
  */
 function hashSignatureArray(signatureArray, secret = null) {
     // const hash = crypto.createHash('sha256');
@@ -170,11 +206,11 @@ LearnositySDK.disableTelemetry = function () {
 /**
  * @see https://github.com/Learnosity/learnosity-sdk-nodejs For more information
  *
- * @param service        string
- * @param securityPacket object
- * @param secret         string
- * @param requestPacket  object
- * @param action         object
+ * @param {Service} service
+ * @param {SecurityPacket} securityPacket
+ * @param {string} secret
+ * @param {RequestPacket} requestPacket
+ * @param {Action} [action]
  *
  * @returns object The init options for a Learnosity API
  */

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.2",
   "description": "Learnosity NodeJS SDK",
   "main": "index.js",
+  "types": "index.d.ts",
   "keywords": [
     "learnosity",
     "sdk"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "strict": false
+  },
+  "include": ["index.js"]
+}


### PR DESCRIPTION
This pull request aims to add type hints by updating the comments in `index.js` to conform to [JSDoc](https://jsdoc.app/). Both Javascript and Typescript use the same language server (i.e., tsserver), which has built-in support for JSDoc comments.

I haven't touched any of the actual code -- only the comments.

The types are automatically generated by running `npx tsc`, which outputs the declaration file to `index.d.ts`.

---

Please let me know if there's anything I overlooked or if you need any further clarification.