### PR TITLE
[CONFIG] update travis dist config to use ubuntu focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+dist: focal
 node_js:
 - 18
 - 20


### PR DESCRIPTION
Added the dist option to the travis.yml file to target Ubuntu 20 (`focal`) instead of the default `xenial` option

Travis builds before: https://app.travis-ci.com/github/Learnosity/learnosity-sdk-nodejs/builds/274367330?serverType=git

Travis builds after: https://app.travis-ci.com/github/Learnosity/learnosity-sdk-nodejs/builds/274405449?serverType=git

## Screenshots
![Screenshot 2025-03-03 at 13 51 32](https://github.com/user-attachments/assets/83fc98f6-2c5a-4fb3-a75e-b82e9d10de5e)

