### PR TITLE
[FIX] Add Events API support to init() (LRN-51428)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Added Events API support to `init()`. The SDK now correctly generates per-user hashes, excludes request data from the signature, and outputs under the `config` key as expected by the Events API client. (LRN-51428)
 
 ## [v0.7.1] - 2026-06-02
 ### Removed

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -132,6 +132,91 @@ run node.js application: node app.js
 check browser: http://localhost:3000/
 ```
 
+## Events API Example
+
+``` javascript
+app.js:
+
+const Learnosity = require('learnosity-sdk-nodejs');
+const express = require('express');
+const app = express();
+
+app.set('view engine', 'ejs');
+
+app.get('/', function (req, res) {
+    const learnositySdk = new Learnosity();
+
+    // The Events API request takes an array of user IDs to monitor.
+    // The SDK will generate the per-user authentication hashes automatically.
+    const signedRequest = learnositySdk.init(
+        // service type
+        'events',
+
+        // security details
+        {
+            'consumer_key': 'yis0TYCu7U9V4o7M',
+            'domain':       'localhost',
+            'user_id':      'teacher-001'
+        },
+
+        // secret
+        '74c5fd430cf1242a527f6223aebd42d30464be22',
+
+        // request details - pass user IDs as an array
+        {
+            'users': ['student-001', 'student-002', 'student-003']
+        }
+    );
+
+    res.render('index', { signedRequest: signedRequest });
+});
+
+app.listen(3000, function () {
+    console.log('Example app listening on port 3000!');
+});
+```
+
+``` html
+index.ejs:
+
+<!DOCTYPE html>
+<html>
+<head lang='en'>
+    <meta charset='UTF-8'>
+    <title>Learnosity SDK - Events API</title>
+</head>
+<body>
+<script src='https://events.learnosity.com/?v2026.2.LTS'></script>
+<script>
+    const signedRequest = <%- JSON.stringify(signedRequest) %>
+
+    const eventsApp = LearnosityEvents.init(signedRequest, {
+        readyListener: function () {
+            console.log('Events API is ready');
+            // Subscribe to events from the users specified in the init
+            const userIds = Object.keys(signedRequest.config.users);
+            const events = userIds.map(function (userId) {
+                return {
+                    kind: 'assess_logging',
+                    user_id: userId,
+                    activity_id: 'my-activity-id'
+                };
+            });
+            eventsApp.on(events, function (event) {
+                console.log('Received event:', event);
+            });
+        },
+        errorListener: function (e) {
+            console.log('Error:', e);
+        }
+    });
+</script>
+</body>
+</html>
+```
+
+**Note:** The SDK output for Events API uses `config` (not `request`) as the top-level key alongside `security`. The per-user hashes are placed in `security.users` automatically — you only need to pass an array of user ID strings in the request.
+
 ## Data API - Example 1
 
  ``` javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,5 +60,5 @@ type RequestMeta = {
     };
 };
 type RequestPacket = Record<string, any> & RequestMeta;
-type Service = 'assess' | 'author' | 'authoraide' | 'items' | 'reports' | 'questions' | 'data';
+type Service = 'assess' | 'author' | 'authoraide' | 'events' | 'items' | 'reports' | 'questions' | 'data';
 type Action = 'get' | 'set' | 'update';

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ const moduleInfo = require('./package.json');
  */
 
 /**
- * @typedef {'assess' | 'author' | 'items' | 'reports' | 'questions' | 'data'} Service
+ * @typedef {'assess' | 'author' | 'authoraide' | 'events' | 'items' | 'reports' | 'questions' | 'data'} Service
  */
 
 /**
@@ -148,7 +148,7 @@ function generateSignature(
     }
 
     // Add the requestPacket if necessary
-    const signRequestData = !(service === 'assess' || service === 'questions');
+    const signRequestData = !(service === 'assess' || service === 'questions' || service === 'events');
 
     if (signRequestData && requestString && requestString.length > 0) {
         signatureArray.push(requestString);
@@ -239,11 +239,39 @@ LearnositySDK.prototype.init = function (
     }
 
     // Automatically populate the user_id of the security packet.
-    if (_.contains(['author', 'items', 'reports', 'authoraide'], service)) {
+    if (_.contains(['author', 'items', 'reports', 'authoraide', 'events'], service)) {
         // The Events API requires a user_id, so we make sure it's a part
         // of the security packet as we share the signature in some cases
         if (!securityPacket.user_id && requestObject && requestObject.user_id) {
             securityPacket.user_id = requestObject.user_id;
+        }
+    }
+
+    // For Events API, generate per-user hashes and place them in the security packet.
+    // Each hash is SHA256(user_id + secret). The users field in the request can be
+    // either an array of user ID strings, or an object with user IDs as keys.
+    if (service === 'events' && requestObject && requestObject.users) {
+        const users = requestObject.users;
+        const hashedUsers = {};
+
+        if (Array.isArray(users)) {
+            users.forEach(function (userId) {
+                hashedUsers[userId] = crypto
+                    .createHash('sha256')
+                    .update(userId + secret)
+                    .digest('hex');
+            });
+        } else if (typeof users === 'object') {
+            Object.keys(users).forEach(function (userId) {
+                hashedUsers[userId] = crypto
+                    .createHash('sha256')
+                    .update(userId + secret)
+                    .digest('hex');
+            });
+        }
+
+        if (Object.keys(hashedUsers).length > 0) {
+            securityPacket.users = hashedUsers;
         }
     }
 
@@ -273,6 +301,11 @@ LearnositySDK.prototype.init = function (
         output = _.extend(securityPacket, requestObject);
     } else if (service === 'assess') {
         output = requestObject;
+    } else if (service === 'events') {
+        output = {
+            'security': securityPacket,
+            'config': _.isString(requestPacket) ? requestString : requestObject
+        };
     } else {
         output = {
             'security': securityPacket,

--- a/test/fixtures/requests/eventsAPI.json
+++ b/test/fixtures/requests/eventsAPI.json
@@ -1,0 +1,3 @@
+{
+    "users": ["student-001", "student-002"]
+}

--- a/test/fixtures/requests/index.js
+++ b/test/fixtures/requests/index.js
@@ -22,6 +22,7 @@ const requestStrings = {
     assess: loadJson('assessAPI'),
     author: loadJson('authorAPI'),
     data: loadJson('dataAPI'),
+    events: loadJson('eventsAPI'),
     items: loadJson('itemsAPI'),
     questions: loadJson('questionsAPI'),
     reports: loadJson('reportsAPI')
@@ -46,6 +47,9 @@ function getSDKParamsFor(service) {
             break;
         case 'items':
             params.security.user_id = params.request.user_id;
+            break;
+        case 'events':
+            params.security.user_id = 'demo-teacher';
             break;
         default:
             // nothing

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -44,6 +44,11 @@ describe('init function', () => {
             service: 'reports',
             signature: '$02$8e0069e7aa8058b47509f35be236c53fa1a878c64b12589fd42f48b568f6ac84',
             outputString: '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","signature":"$02$8e0069e7aa8058b47509f35be236c53fa1a878c64b12589fd42f48b568f6ac84"},"request":{"reports":[{"id":"report-1","type":"sessions-summary","user_id":"$ANONYMIZED_USER_ID","session_ids":["AC023456-2C73-44DC-82DA28894FCBC3BF"]}]}}'
+        },
+        {
+            service: 'events',
+            signature: '$02$a9ecc64ebf6f33c2069fcd6e1284eb51f9ea52c27661b0f9158509e8625b3374',
+            outputString: '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","user_id":"demo-teacher","users":{"student-001":"48341c9ae4775c8a0cc5ffed8bf99a8ac33be3ce44dfcf03a61cb62dc5935bbc","student-002":"0bd5a3d9a24e16413568795cd79192455fd308328f5ed6b0397f15c8ff23003d"},"signature":"$02$a9ecc64ebf6f33c2069fcd6e1284eb51f9ea52c27661b0f9158509e8625b3374"},"config":{"users":["student-001","student-002"]}}'
         }
     ];
 


### PR DESCRIPTION
## Summary

The Node SDK had no handling for the `events` service type. Calling `init('events', ...)` produced an incorrectly structured output, causing 403 errors on `/lastevents` and `/subscribe` when `eventsApp.on()` was invoked.

## Root Cause

Three issues:

1. **Wrong output key** — SDK output `{ security, request }` but the Events API client expects `{ security, config }`
2. **Missing user hashes** — Per-user SHA256 credentials (required for subscribe auth) were not being generated or placed in `security.users`
3. **Invalid signature** — Request body was included in the HMAC signature, but Events API (like Questions/Assess) does not sign request data

## Changes

- `index.js`: Add events-specific logic for signature, user hashing, and output structure
- `index.d.ts`: Add `'events'` to Service type
- `REFERENCE.md`: Add Events API usage example
- `test/`: Add signature and output validation for events service

## Testing

- Reproduced 403s using customer reproduction app against buggy SDK
- Confirmed 403s resolved after fix with same reproduction app
- All 35 unit tests passing

## Customer Impact

Users of the Events API via the Node SDK need to:
- Update references from `signedRequest.request` to `signedRequest.config`
- Users can now pass a simple array of user IDs instead of pre-computing hashes