### PR TITLE
[DOC] Update changelog for v0.7.1 release (LRN-51520)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [v0.7.1] - 2026-06-25
 ### Fixed
-- Added Events API support to `init()`. The SDK now correctly generates per-user hashes, excludes request data from the signature, and outputs under the `config` key as expected by the Events API client. (LRN-51428)
+- Added Events API support to `init()`. The SDK now correctly generates per-user hashes, excludes request data from the signature, and outputs under the `config` key as expected by the Events API client.
 
 ### Removed
-- Removed Travis CI configuration and references. (LRN-51186)
+- Removed Travis CI configuration and references.
 
 ## [v0.7.0] - 2026-01-07
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,12 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v0.7.1] - 2026-06-25
 ### Fixed
 - Added Events API support to `init()`. The SDK now correctly generates per-user hashes, excludes request data from the signature, and outputs under the `config` key as expected by the Events API client. (LRN-51428)
 
-## [v0.7.1] - 2026-06-02
 ### Removed
-- Removed Travis CI configuration and references.
+- Removed Travis CI configuration and references. (LRN-51186)
 
 ## [v0.7.0] - 2026-01-07
 ### Added


### PR DESCRIPTION
## Summary
- Consolidates the unreleased Events API fix (LRN-51428) and Travis CI removal (LRN-51186) under a single v0.7.1 changelog entry dated today.
- The previous v0.7.1 entry (dated 2026-06-02) was never tagged or released, so this corrects the date and combines both changes.

## Next steps after merge
1. Tag master: `git tag v0.7.1 && git push origin v0.7.1`
2. Create a GitHub Release from the tag titled `[RELEASE] v0.7.1`