### PR TITLE
[FIX] Events API user hashes placed in wrong location (LRN-51428)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v0.7.2] - 2026-06-26
+### Fixed
+- Fixed Events API user hashes being placed in `security` instead of `config`, which caused 403 errors on event subscriptions.
+
+### Added
+- Added Events API quickstart example.
+
 ## [v0.7.1] - 2026-06-25
 ### Fixed
 - Added Events API support to `init()`. The SDK now correctly generates per-user hashes, excludes request data from the signature, and outputs under the `config` key as expected by the Events API client.

--- a/docs/quickstart/index.js
+++ b/docs/quickstart/index.js
@@ -167,6 +167,54 @@ app.get('/authoraide', function (req, res) {
     res.render('main', { request });
 });
 
+// Events API - Live proctoring / event monitoring
+app.get('/eventsapi', function (req, res) {
+    const learnositySdk = new Learnosity();
+    const user_id = 'demo-student-001';
+    const session_id = Learnosity.Uuid.generate();
+
+    // Sign the Items API request (the assessment the student takes)
+    const itemsRequest = learnositySdk.init(
+        'items',
+        {
+            consumer_key: config.consumerKey,
+            domain: domain
+        },
+        config.consumerSecret,
+        {
+            user_id: user_id,
+            activity_template_id: 'quickstart_examples_activity_template_001',
+            session_id: session_id,
+            activity_id: 'quickstart_examples_activity_001',
+            rendering_type: 'assess',
+            type: 'submit_practice',
+            name: 'Items API Quickstart',
+            state: 'initial',
+            config: {
+                configuration: {
+                    events: true
+                }
+            }
+        }
+    );
+
+    // Sign the Events API request (the teacher/proctor monitors events)
+    const eventsRequest = learnositySdk.init(
+        'events',
+        {
+            consumer_key: config.consumerKey,
+            domain: domain,
+            user_id: 'demo-teacher'
+        },
+        config.consumerSecret,
+        {
+            users: [user_id]
+        }
+    );
+
+    res.render('events', { itemsRequest, eventsRequest });
+});
+
 // Data API
 app.get('/dataapi', async function (req, res) {
     const itembank_uri = 'https://data.learnosity.com/latest-lts/itembank/items';

--- a/docs/quickstart/views/events.ejs
+++ b/docs/quickstart/views/events.ejs
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+    <title>Learnosity SDK - Events API</title>
+    <script src="//items.learnosity.com/?latest-lts"></script>
+    <script src="//events.learnosity.com/?latest-lts"></script>
+</head>
+<body>
+    <h1>Items API + Events API Example</h1>
+    <p>Open the browser console to see Events API output.</p>
+
+    <div id="learnosity_assess"></div>
+
+    <script>
+        const signedRequestItems = <%- JSON.stringify(itemsRequest) %>;
+        const signedRequestEvents = <%- JSON.stringify(eventsRequest) %>;
+
+        console.log('Items API init object:', signedRequestItems);
+        console.log('Events API init object:', signedRequestEvents);
+
+        // Initialize Items API (the assessment)
+        window.itemsApp = LearnosityItems.init(signedRequestItems, {
+            readyListener() {
+                console.log('Items API is successfully initialized');
+            },
+            errorListener(err) {
+                console.log('Items API error:', err);
+            }
+        });
+
+        // Initialize Events API (live proctoring / event monitoring)
+        window.eventsApp = LearnosityEvents.init(signedRequestEvents, {
+            readyListener() {
+                console.log('Events API is successfully initialized');
+
+                // Get user IDs from the signed config
+                const users = signedRequestEvents.config.users;
+                const userIds = Array.isArray(users) ? users : Object.keys(users);
+                console.log('User IDs to monitor:', userIds);
+
+                // Subscribe to assess_logging events for each user
+                const events = userIds.map((user_id) => ({
+                    kind: 'assess_logging',
+                    user_id: user_id,
+                    activity_id: 'quickstart_examples_activity_001'
+                }));
+
+                eventsApp.on(events, (event) => {
+                    console.log('Received Events API event:');
+                    console.dir(event, { depth: null });
+                });
+            },
+            errorListener(error) {
+                console.log('Events API error:', error);
+            }
+        });
+    </script>
+</body>
+</html>

--- a/docs/quickstart/views/index.ejs
+++ b/docs/quickstart/views/index.ejs
@@ -112,6 +112,11 @@
                     <td>Data retrieval and pagination example</td>
                     <td><a href="/dataapi">View Demo</a></td>
                 </tr>
+                <tr>
+                    <td><strong>Events API</strong></td>
+                    <td>Live proctoring and event monitoring</td>
+                    <td><a href="/eventsapi">View Demo</a></td>
+                </tr>
             </tbody>
         </table>
 

--- a/index.js
+++ b/index.js
@@ -271,7 +271,7 @@ LearnositySDK.prototype.init = function (
         }
 
         if (Object.keys(hashedUsers).length > 0) {
-            securityPacket.users = hashedUsers;
+            requestObject.users = hashedUsers;
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learnosity-sdk-nodejs",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Learnosity NodeJS SDK",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -48,7 +48,7 @@ describe('init function', () => {
         {
             service: 'events',
             signature: '$02$a9ecc64ebf6f33c2069fcd6e1284eb51f9ea52c27661b0f9158509e8625b3374',
-            outputString: '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","user_id":"demo-teacher","users":{"student-001":"48341c9ae4775c8a0cc5ffed8bf99a8ac33be3ce44dfcf03a61cb62dc5935bbc","student-002":"0bd5a3d9a24e16413568795cd79192455fd308328f5ed6b0397f15c8ff23003d"},"signature":"$02$a9ecc64ebf6f33c2069fcd6e1284eb51f9ea52c27661b0f9158509e8625b3374"},"config":{"users":["student-001","student-002"]}}'
+            outputString: '{"security":{"consumer_key":"yis0TYCu7U9V4o7M","domain":"localhost","timestamp":"20140626-0528","user_id":"demo-teacher","signature":"$02$a9ecc64ebf6f33c2069fcd6e1284eb51f9ea52c27661b0f9158509e8625b3374"},"config":{"users":{"student-001":"48341c9ae4775c8a0cc5ffed8bf99a8ac33be3ce44dfcf03a61cb62dc5935bbc","student-002":"0bd5a3d9a24e16413568795cd79192455fd308328f5ed6b0397f15c8ff23003d"}}}'
         }
     ];
 


### PR DESCRIPTION
## Summary
The Events API user hashes were being placed in `security.users` instead of `config.users`. This caused 403 errors when the client tried to subscribe to event topics, because the event bus couldn't find the authentication hashes where it expected them.

## Changes
- Fixed `index.js` to place hashed users in the request object (output as `config.users`) instead of the security packet
- Updated test to assert correct output structure
- Bumped version to 0.7.2
- Added Events API quickstart example

## Testing
- Verified fix resolves the 403 subscription error in the browser
- All unit tests passing